### PR TITLE
Add Preguntas screen with local question

### DIFF
--- a/assets/data/pregunta.json
+++ b/assets/data/pregunta.json
@@ -1,0 +1,25 @@
+{
+  "pregunta":"Cual es la capital de Ecuador?",
+  "opciones":[
+    {
+      "orden":"1",
+      "opcion":"Quito",
+      "esCorrecta": "true"
+    },
+    {
+      "orden":"2",
+      "opcion":"Ambato",
+      "esCorrecta": "false"
+    },
+    {
+      "orden":"3",
+      "opcion":"Guayaquil",
+      "esCorrecta": "false"
+    },
+    {
+      "orden":"4",
+      "opcion":"Riobamba",
+      "esCorrecta": "false"
+    }
+  ]
+}

--- a/lib/models/question.dart
+++ b/lib/models/question.dart
@@ -1,0 +1,30 @@
+class Option {
+  final int orden;
+  final String opcion;
+  final bool esCorrecta;
+
+  Option({required this.orden, required this.opcion, required this.esCorrecta});
+
+  factory Option.fromJson(Map<String, dynamic> json) {
+    return Option(
+      orden: int.parse(json['orden'].toString()),
+      opcion: json['opcion'] as String,
+      esCorrecta: json['esCorrecta'].toString().toLowerCase() == 'true',
+    );
+  }
+}
+
+class Question {
+  final String pregunta;
+  final List<Option> opciones;
+
+  Question({required this.pregunta, required this.opciones});
+
+  factory Question.fromJson(Map<String, dynamic> json) {
+    final opcionesJson = json['opciones'] as List<dynamic>;
+    return Question(
+      pregunta: json['pregunta'] as String,
+      opciones: opcionesJson.map((e) => Option.fromJson(e)).toList(),
+    );
+  }
+}

--- a/lib/screen/category_screen.dart
+++ b/lib/screen/category_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'preguntas_screen.dart';
 
 class CategoryScreen extends StatelessWidget {
   const CategoryScreen({super.key});
@@ -46,7 +47,11 @@ class CategoryScreen extends StatelessWidget {
                     const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                // TODO: Navegar a pantalla de preguntas
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const PreguntasScreen(),
+                  ),
+                );
               },
               child: const Text('COMENZAR TRIVIA'),
             ),

--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../models/question.dart';
+
+class PreguntasScreen extends StatefulWidget {
+  const PreguntasScreen({super.key});
+
+  @override
+  State<PreguntasScreen> createState() => _PreguntasScreenState();
+}
+
+class _PreguntasScreenState extends State<PreguntasScreen>
+    with SingleTickerProviderStateMixin {
+  late Future<Question> _futureQuestion;
+  bool _showCorrect = false;
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureQuestion = _loadQuestion();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    );
+  }
+
+  Future<Question> _loadQuestion() async {
+    final data = await rootBundle.loadString('assets/data/pregunta.json');
+    final jsonMap = json.decode(data) as Map<String, dynamic>;
+    return Question.fromJson(jsonMap);
+  }
+
+  void _onOptionSelected(Option option) {
+    if (option.esCorrecta) {
+      setState(() {
+        _showCorrect = true;
+      });
+      _controller.forward(from: 0.0);
+    }
+  }
+
+  Widget _buildCorrectAnimation() {
+    return _showCorrect
+        ? Center(
+            child: ScaleTransition(
+              scale: _controller,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: const [
+                  Icon(Icons.check_circle,
+                      size: 80, color: Colors.green),
+                  SizedBox(height: 8),
+                  Text(
+                    'Respuesta correcta',
+                    style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.green),
+                  ),
+                ],
+              ),
+            ),
+          )
+        : const SizedBox.shrink();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pregunta'),
+      ),
+      body: FutureBuilder<Question>(
+        future: _futureQuestion,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final question = snapshot.data!;
+          return Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      question.pregunta,
+                      style: const TextStyle(
+                          fontSize: 24, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 24),
+                    ...question.opciones.map((option) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8.0),
+                        child: ElevatedButton(
+                          onPressed: () => _onOptionSelected(option),
+                          style: ElevatedButton.styleFrom(
+                            minimumSize: const Size.fromHeight(48),
+                          ),
+                          child: Text(option.opcion),
+                        ),
+                      );
+                    }).toList(),
+                  ],
+                ),
+              ),
+              _buildCorrectAnimation(),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,9 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/data/pregunta.json
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Summary
- add local JSON with example question
- add Question and Option models
- create PreguntasScreen to load question and show animation on correct answer
- link CategoryScreen button to new PreguntasScreen
- register JSON asset in pubspec

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687082c6166c832f99db01e4b72ff394