### PR TITLE
Remove debug label banner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
         // This is the theme of your application.
         //


### PR DESCRIPTION
## Summary
- hide the debug banner by adding `debugShowCheckedModeBanner: false` in `MaterialApp`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687085bf663c832fb408a04758be4c09