### PR TITLE
Update start screen and add incorrect answer alert

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'screen/category_screen.dart';
+import 'screen/category_random_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const CategoryScreen(),
+      home: const CategoryRandomScreen(),
     );
   }
 }

--- a/lib/screen/category_random_screen.dart
+++ b/lib/screen/category_random_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'preguntas_screen.dart';
 
 /// Screen that displays a roulette style wheel with different trivia
 /// categories. When the wheel is tapped it spins and stops on a random
@@ -73,6 +74,11 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
     setState(() {
       _selectedCategory = _categories[index];
     });
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => const PreguntasScreen(),
+      ),
+    );
   }
 
   @override

--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -16,6 +16,7 @@ class _PreguntasScreenState extends State<PreguntasScreen>
     with SingleTickerProviderStateMixin {
   late Future<Question> _futureQuestion;
   bool _showCorrect = false;
+  bool _showIncorrect = false;
   late AnimationController _controller;
 
   @override
@@ -38,9 +39,15 @@ class _PreguntasScreenState extends State<PreguntasScreen>
     if (option.esCorrecta) {
       setState(() {
         _showCorrect = true;
+        _showIncorrect = false;
       });
-      _controller.forward(from: 0.0);
+    } else {
+      setState(() {
+        _showIncorrect = true;
+        _showCorrect = false;
+      });
     }
+    _controller.forward(from: 0.0);
   }
 
   Widget _buildCorrectAnimation() {
@@ -60,6 +67,30 @@ class _PreguntasScreenState extends State<PreguntasScreen>
                         fontSize: 24,
                         fontWeight: FontWeight.bold,
                         color: Colors.green),
+                  ),
+                ],
+              ),
+            ),
+          )
+        : const SizedBox.shrink();
+  }
+
+  Widget _buildIncorrectAnimation() {
+    return _showIncorrect
+        ? Center(
+            child: ScaleTransition(
+              scale: _controller,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: const [
+                  Icon(Icons.cancel, size: 80, color: Colors.red),
+                  SizedBox(height: 8),
+                  Text(
+                    'Respuesta incorrecta',
+                    style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.red),
                   ),
                 ],
               ),
@@ -110,6 +141,7 @@ class _PreguntasScreenState extends State<PreguntasScreen>
                 ),
               ),
               _buildCorrectAnimation(),
+              _buildIncorrectAnimation(),
             ],
           );
         },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,8 +59,6 @@ flutter:
   uses-material-design: true
   assets:
     - assets/data/categories.json
-
-  assets:
     - assets/data/pregunta.json
 
   # To add assets to your application, add an assets section, like this:


### PR DESCRIPTION
## Summary
- launch the app on `CategoryRandomScreen`
- navigate to question when roulette animation completes
- show incorrect answer feedback in `PreguntasScreen`
- include both asset files in `pubspec.yaml`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870859fcad0832fa217592d627b762e