### PR TITLE
Add basic login screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'screen/category_screen.dart';
+import 'screen/login_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const CategoryScreen(),
+      home: const LoginScreen(),
     );
   }
 }

--- a/lib/screen/login_screen.dart
+++ b/lib/screen/login_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'category_random_screen.dart';
+
+/// Pantalla de inicio de sesión con opciones para autenticarse
+/// mediante redes sociales o continuar como invitado.
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  void _onLoginComplete(BuildContext context) {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (context) => const CategoryRandomScreen(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Iniciar sesión')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton.icon(
+              icon: const Icon(Icons.mail_outline),
+              label: const Text('Registrarse con Google'),
+              onPressed: () => _onLoginComplete(context),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.facebook),
+              label: const Text('Registrarse con Facebook'),
+              onPressed: () => _onLoginComplete(context),
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.person_outline),
+              label: const Text('Continuar como invitado'),
+              onPressed: () => _onLoginComplete(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement LoginScreen with options for Google, Facebook, or guest
- route to `CategoryRandomScreen` after login
- make LoginScreen the app entry point

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687086858a1c832f89c13a092e440db0