### PR TITLE
Fix LateInitializationError on roulette screen

### DIFF
--- a/lib/screen/category_random_screen.dart
+++ b/lib/screen/category_random_screen.dart
@@ -32,6 +32,7 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
               _determineSelectedCategory();
             }
           });
+    _animation = Tween<double>(begin: 0, end: 0).animate(_controller);
     _loadCategories();
   }
 


### PR DESCRIPTION
## Summary
- initialize `_animation` in `CategoryRandomScreen` so it always has a value

## Testing
- `flutter test` *(fails: `command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68708837e890832f91a6468de2d3df74