### PR TITLE
Fix JSON parsing and arrow rotation

### DIFF
--- a/lib/screen/category_random_screen.dart
+++ b/lib/screen/category_random_screen.dart
@@ -95,18 +95,25 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
               child: SizedBox(
                 width: 250,
                 height: 250,
-                child: AnimatedBuilder(
-                  animation: _controller,
-                  builder: (context, child) {
-                    return Transform.rotate(
-                      angle: _animation.value,
-                      child: child,
-                    );
-                  },
-                  child: CustomPaint(
-                    painter:
-                        _WheelPainter(categories: _categories),
-                  ),
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    AnimatedBuilder(
+                      animation: _controller,
+                      builder: (context, child) {
+                        return Transform.rotate(
+                          angle: _animation.value,
+                          child: child,
+                        );
+                      },
+                      child:
+                          CustomPaint(painter: _WheelPainter(categories: _categories)),
+                    ),
+                    const CustomPaint(
+                      size: Size(250, 250),
+                      painter: _ArrowPainter(),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -173,29 +180,33 @@ class _WheelPainter extends CustomPainter {
       textPainter.paint(canvas, offset);
     }
 
-    // draw arrow
-    final arrowPaint = Paint()
-      ..color = Colors.black
-      ..strokeWidth = 3;
-    canvas.drawLine(
-      Offset(center.dx, 0),
-      Offset(center.dx, 20),
-      arrowPaint,
-    );
-    canvas.drawPolygon([
-      Offset(center.dx - 10, 20),
-      Offset(center.dx + 10, 20),
-      Offset(center.dx, 35)
-    ], arrowPaint);
   }
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
 
-extension on Canvas {
-  void drawPolygon(List<Offset> points, Paint paint) {
-    final path = Path()..addPolygon(points, true);
-    drawPath(path, paint);
+class _ArrowPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final centerX = size.width / 2;
+    final paint = Paint()
+      ..color = Colors.black
+      ..strokeWidth = 3
+      ..style = PaintingStyle.fill;
+    canvas.drawLine(
+      Offset(centerX, 0),
+      Offset(centerX, 20),
+      paint,
+    );
+    final path = Path()
+      ..moveTo(centerX - 10, 20)
+      ..lineTo(centerX + 10, 20)
+      ..lineTo(centerX, 35)
+      ..close();
+    canvas.drawPath(path, paint);
   }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -31,8 +32,11 @@ class _PreguntasScreenState extends State<PreguntasScreen>
 
   Future<Question> _loadQuestion() async {
     final data = await rootBundle.loadString('assets/data/pregunta.json');
-    final jsonMap = json.decode(data) as Map<String, dynamic>;
-    return Question.fromJson(jsonMap);
+    final List<dynamic> jsonList = json.decode(data) as List<dynamic>;
+    final random = Random();
+    final Map<String, dynamic> questionMap =
+        jsonList[random.nextInt(jsonList.length)] as Map<String, dynamic>;
+    return Question.fromJson(questionMap);
   }
 
   void _onOptionSelected(Option option) {


### PR DESCRIPTION
## Summary
- parse question data from array and pick a random question
- keep roulette arrow static when spinning

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68708ac8675c832fbbd81707f3b50dc0