### PR TITLE
Integrate simple auth service

### DIFF
--- a/lib/screen/login_screen.dart
+++ b/lib/screen/login_screen.dart
@@ -1,10 +1,33 @@
 import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
 import 'category_random_screen.dart';
 
 /// Pantalla de inicio de sesión con opciones para autenticarse
 /// mediante redes sociales o continuar como invitado.
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
+
+  Future<void> _loginGuest(BuildContext context) async {
+    try {
+      await AuthService().loginAsGuest();
+      _onLoginComplete(context);
+    } catch (_) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Error al iniciar sesión')),
+      );
+    }
+  }
+
+  Future<void> _loginSocial(BuildContext context) async {
+    try {
+      await AuthService().socialLogin();
+      _onLoginComplete(context);
+    } catch (_) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Error al iniciar sesión')),
+      );
+    }
+  }
 
   void _onLoginComplete(BuildContext context) {
     Navigator.of(context).pushReplacement(
@@ -27,19 +50,19 @@ class LoginScreen extends StatelessWidget {
             ElevatedButton.icon(
               icon: const Icon(Icons.mail_outline),
               label: const Text('Registrarse con Google'),
-              onPressed: () => _onLoginComplete(context),
+              onPressed: () => _loginSocial(context),
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
               icon: const Icon(Icons.facebook),
               label: const Text('Registrarse con Facebook'),
-              onPressed: () => _onLoginComplete(context),
+              onPressed: () => _loginSocial(context),
             ),
             const SizedBox(height: 16),
             OutlinedButton.icon(
               icon: const Icon(Icons.person_outline),
               label: const Text('Continuar como invitado'),
-              onPressed: () => _onLoginComplete(context),
+              onPressed: () => _loginGuest(context),
             ),
           ],
         ),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Service that handles authentication and stores the JWT token.
+class AuthService {
+  AuthService._();
+
+  static final AuthService _instance = AuthService._();
+  factory AuthService() => _instance;
+
+  /// Base url of the backend. Replace `{{URL}}` with the real host.
+  final String baseUrl = '{{URL}}';
+
+  String? token;
+
+  /// Login using fixed credentials when the user continues as guest.
+  Future<void> loginAsGuest() async {
+    final response = await http.post(
+      Uri.parse('${baseUrl}api/login'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'email': 'daniel@gmail.com',
+        'password': '123456',
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      token = data['token']?.toString();
+    } else {
+      throw Exception('Failed to login as guest');
+    }
+  }
+
+  /// Login for social network sign in.
+  Future<void> socialLogin() async {
+    final response = await http.post(
+      Uri.parse('${baseUrl}api/social_login'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'email': 'juan@gmail.com'}),
+    );
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      token = data['token']?.toString();
+    } else {
+      throw Exception('Failed to login with social network');
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  http: ^0.13.6
+
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add an `AuthService` to call backend login endpoints
- use the new service from `LoginScreen`
- add `http` package dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733c3f2a64832fa51cc1595517810c