### PR TITLE
Read auth config from env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Ignore environment files
+.env

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'screen/login_screen.dart';
 
 
-void main() {
+Future<void> main() async {
+  await dotenv.load(fileName: '.env');
   runApp(const MyApp());
 }
 

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 /// Service that handles authentication and stores the JWT token.
 class AuthService {
@@ -9,8 +10,11 @@ class AuthService {
   static final AuthService _instance = AuthService._();
   factory AuthService() => _instance;
 
-  /// Base url of the backend. Replace `{{URL}}` with the real host.
-  final String baseUrl = '{{URL}}';
+  /// Base url of the backend loaded from the environment.
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? '';
+
+  /// Secret key loaded from the environment for API authentication.
+  final String secretKey = dotenv.env['SECRET_KEY'] ?? '';
 
   String? token;
 
@@ -18,7 +22,10 @@ class AuthService {
   Future<void> loginAsGuest() async {
     final response = await http.post(
       Uri.parse('${baseUrl}api/login'),
-      headers: {'Content-Type': 'application/json'},
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': secretKey,
+      },
       body: jsonEncode({
         'email': 'daniel@gmail.com',
         'password': '123456',
@@ -38,7 +45,10 @@ class AuthService {
   Future<void> socialLogin() async {
     final response = await http.post(
       Uri.parse('${baseUrl}api/social_login'),
-      headers: {'Content-Type': 'application/json'},
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': secretKey,
+      },
       body: jsonEncode({'email': 'juan@gmail.com'}),
     );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
 
   http: ^0.13.6
+  flutter_dotenv: ^5.0.2
 
 
   # The following adds the Cupertino Icons font to your application.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,9 +8,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:trivia_ecuatoriana/main.dart';
 
 void main() {
+  setUpAll(() async {
+    await dotenv.load(fileName: '.env');
+  });
+
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());


### PR DESCRIPTION
## Summary
- ignore `.env` files
- load `.env` with `flutter_dotenv`
- use `API_BASE_URL` and `SECRET_KEY` for AuthService
- send `x-api-key` header on login calls
- update widget test to load env

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733f996cc8832faf3a852ff3dcb197