### PR TITLE
Implement API-driven question flow

### DIFF
--- a/lib/screen/category_random_screen.dart
+++ b/lib/screen/category_random_screen.dart
@@ -78,7 +78,7 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
     });
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (_) => const PreguntasScreen(),
+        builder: (_) => const PreguntasScreen(categoryId: 1),
       ),
     );
   }

--- a/lib/screen/category_screen.dart
+++ b/lib/screen/category_screen.dart
@@ -13,11 +13,23 @@ class CategoryScreen extends StatefulWidget {
 
 class _CategoryScreenState extends State<CategoryScreen> {
   late Future<List<Category>> _futureCategories;
+  int _correctAnswers = 0;
 
   @override
   void initState() {
     super.initState();
     _futureCategories = CategoryService().fetchCategories();
+  }
+
+  Future<void> _openQuestion(int categoryId) async {
+    final result = await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => PreguntasScreen(categoryId: categoryId),
+      ),
+    );
+    if (result == true) {
+      setState(() => _correctAnswers++);
+    }
   }
 
   @override
@@ -43,6 +55,11 @@ class _CategoryScreenState extends State<CategoryScreen> {
                     color: Colors.yellow,
                   ),
                 ),
+                const SizedBox(height: 8),
+                Text(
+                  'Aciertos: $_correctAnswers',
+                  style: const TextStyle(fontSize: 20, color: Colors.white),
+                ),
                 const SizedBox(height: 30),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24.0),
@@ -57,7 +74,11 @@ class _CategoryScreenState extends State<CategoryScreen> {
                     ),
                     itemBuilder: (context, index) {
                       final c = categories[index];
-                      return CategoryItem(iconUrl: c.icono, label: c.nombre);
+                      return CategoryItem(
+                        iconUrl: c.icono,
+                        label: c.nombre,
+                        onTap: () => _openQuestion(c.id),
+                      );
                     },
                   ),
                 ),
@@ -72,11 +93,9 @@ class _CategoryScreenState extends State<CategoryScreen> {
                         fontSize: 20, fontWeight: FontWeight.bold),
                   ),
                   onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => const PreguntasScreen(),
-                      ),
-                    );
+                    if (categories.isNotEmpty) {
+                      _openQuestion(categories.first.id);
+                    }
                   },
                   child: const Text('COMENZAR TRIVIA'),
                 ),
@@ -112,25 +131,34 @@ class _CategoryScreenState extends State<CategoryScreen> {
 class CategoryItem extends StatelessWidget {
   final String iconUrl;
   final String label;
+  final VoidCallback onTap;
 
-  const CategoryItem({super.key, required this.iconUrl, required this.label});
+  const CategoryItem({
+    super.key,
+    required this.iconUrl,
+    required this.label,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        CircleAvatar(
-          radius: 40,
-          backgroundImage: AssetImage('assets/$iconUrl'),
-          backgroundColor: Colors.blueAccent,
-        ),
-        const SizedBox(height: 8),
-        Text(
-          label,
-          style: const TextStyle(
-              fontSize: 16, fontWeight: FontWeight.w600, color: Colors.white),
-        )
-      ],
+    return InkWell(
+      onTap: onTap,
+      child: Column(
+        children: [
+          CircleAvatar(
+            radius: 40,
+            backgroundImage: AssetImage('assets/$iconUrl'),
+            backgroundColor: Colors.blueAccent,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            label,
+            style: const TextStyle(
+                fontSize: 16, fontWeight: FontWeight.w600, color: Colors.white),
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/services/question_service.dart
+++ b/lib/services/question_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
 import 'auth_service.dart';
+import '../models/question.dart';
 
 class QuestionService {
   Future<void> createQuestion(Map<String, dynamic> body) async {
@@ -22,5 +23,35 @@ class QuestionService {
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception('Error al crear pregunta');
     }
+  }
+
+  Future<List<Question>> fetchQuestions(int categoryId,
+      {int limit = 2, int difficultyId = 1}) async {
+    final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
+    final url = Uri.parse('${baseUrl}api/preguntas');
+    final token = await AuthService().getToken();
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    };
+    if (token != null) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+    final body = {
+      'id_categoria': categoryId,
+      'limit': limit,
+      'id_dificultad': difficultyId,
+    };
+
+    final response =
+        await http.post(url, headers: headers, body: jsonEncode(body));
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body) as List<dynamic>;
+      return data
+          .map((item) => Question.fromJson(item as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('Error al obtener preguntas');
   }
 }


### PR DESCRIPTION
## Summary
- add `QuestionService.fetchQuestions` to call the backend API
- load a question from the API in `PreguntasScreen`
- count correct answers in `CategoryScreen` and navigate when tapping a category
- make `CategoryItem` tappable
- adjust `CategoryRandomScreen` for new `PreguntasScreen` API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785550d1d4832f841cdaa4a7db1114