### PR TITLE
Add audio feedback when answering

### DIFF
--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:audioplayers/audioplayers.dart';
 
 import '../models/question.dart';
 import '../services/question_service.dart';
@@ -20,6 +21,7 @@ class _PreguntasScreenState extends State<PreguntasScreen>
   bool _showCorrectAnswer = false;
   Option? _correctOption;
   late AnimationController _controller;
+  late final AudioPlayer _audioPlayer;
 
   @override
   void initState() {
@@ -29,6 +31,7 @@ class _PreguntasScreenState extends State<PreguntasScreen>
       vsync: this,
       duration: const Duration(milliseconds: 500),
     );
+    _audioPlayer = AudioPlayer();
   }
 
   Future<Question> _fetchQuestion() async {
@@ -39,8 +42,15 @@ class _PreguntasScreenState extends State<PreguntasScreen>
     return questions.first;
   }
 
+  Future<void> _playSound(String asset) async {
+    try {
+      await _audioPlayer.play(AssetSource(asset));
+    } catch (_) {}
+  }
+
   void _onOptionSelected(Option selected, Option correct) {
     if (selected.esCorrecta) {
+      _playSound('sounds/correct.wav');
       setState(() {
         _showCorrect = true;
         _showIncorrect = false;
@@ -48,6 +58,7 @@ class _PreguntasScreenState extends State<PreguntasScreen>
         _correctOption = null;
       });
     } else {
+      _playSound('sounds/incorrect.wav');
       setState(() {
         _showIncorrect = true;
         _showCorrect = false;
@@ -125,6 +136,13 @@ class _PreguntasScreenState extends State<PreguntasScreen>
             ),
           )
         : const SizedBox.shrink();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _audioPlayer.dispose();
+    super.dispose();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   http: ^0.13.6
   flutter_dotenv: ^5.0.2
   shared_preferences: ^2.2.0
+  audioplayers: ^5.1.0
 
 
   # The following adds the Cupertino Icons font to your application.
@@ -64,6 +65,7 @@ flutter:
   assets:
     - assets/data/pregunta.json
     - assets/imagenes/
+    - assets/sounds/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- play sound when the answer is chosen
- register sounds asset and add audioplayers dependency

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a0add084832fab6b28dcfac5c5bc