### PR TITLE
Show trivia category on question screen

### DIFF
--- a/lib/screen/category_random_screen.dart
+++ b/lib/screen/category_random_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'preguntas_screen.dart';
 import '../services/category_service.dart';
+import '../models/category.dart';
 
 /// Screen that displays a roulette style wheel with different trivia
 /// categories. When the wheel is tapped it spins and stops on a random
@@ -18,9 +19,9 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _animation;
-  final List<String> _categories = [];
+  final List<Category> _categories = [];
   double _currentAngle = 0;
-  String? _selectedCategory;
+  Category? _selectedCategory;
 
   @override
   void initState() {
@@ -48,7 +49,7 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
       setState(() {
         _categories
           ..clear()
-          ..addAll(categories.map((e) => e.nombre));
+          ..addAll(categories);
       });
     } catch (_) {
       // In case of error keep categories empty
@@ -78,7 +79,7 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
     });
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (_) => const PreguntasScreen(categoryId: 1),
+        builder: (_) => PreguntasScreen(category: _selectedCategory!),
       ),
     );
   }
@@ -123,7 +124,7 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
             const SizedBox(height: 20),
             if (_selectedCategory != null)
               Text(
-                'Categoría: $_selectedCategory',
+                'Categoría: ${_selectedCategory!.nombre}',
                 style:
                     const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
@@ -139,7 +140,7 @@ class _CategoryRandomScreenState extends State<CategoryRandomScreen>
 class _WheelPainter extends CustomPainter {
   _WheelPainter({required this.categories});
 
-  final List<String> categories;
+  final List<Category> categories;
   final List<Color> _colors = const [
     Colors.red,
     Colors.blue,
@@ -169,7 +170,7 @@ class _WheelPainter extends CustomPainter {
 
       final textPainter = TextPainter(
         text: TextSpan(
-          text: categories[i],
+          text: categories[i].nombre,
           style: const TextStyle(color: Colors.white, fontSize: 12),
         ),
         textDirection: TextDirection.ltr,

--- a/lib/screen/category_screen.dart
+++ b/lib/screen/category_screen.dart
@@ -21,10 +21,10 @@ class _CategoryScreenState extends State<CategoryScreen> {
     _futureCategories = CategoryService().fetchCategories();
   }
 
-  Future<void> _openQuestion(int categoryId) async {
+  Future<void> _openQuestion(Category category) async {
     final result = await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => PreguntasScreen(categoryId: categoryId),
+        builder: (context) => PreguntasScreen(category: category),
       ),
     );
     if (result == true) {
@@ -78,7 +78,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                         return CategoryItem(
                           iconUrl: c.icono,
                           label: c.nombre,
-                          onTap: () => _openQuestion(c.id),
+                          onTap: () => _openQuestion(c),
                         );
                       },
                     ),
@@ -87,7 +87,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                   FilledButton.icon(
                     onPressed: () {
                       if (categories.isNotEmpty) {
-                        _openQuestion(categories.first.id);
+                        _openQuestion(categories.first);
                       }
                     },
                     icon: const Icon(Icons.play_arrow),

--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
 
 import '../models/question.dart';
+import '../models/category.dart';
 import '../services/question_service.dart';
 
 class PreguntasScreen extends StatefulWidget {
-  const PreguntasScreen({super.key, required this.categoryId});
+  const PreguntasScreen({super.key, required this.category});
 
-  final int categoryId;
+  final Category category;
 
   @override
   State<PreguntasScreen> createState() => _PreguntasScreenState();
@@ -35,7 +36,7 @@ class _PreguntasScreenState extends State<PreguntasScreen>
   }
 
   Future<Question> _fetchQuestion() async {
-    final questions = await QuestionService().fetchQuestions(widget.categoryId);
+    final questions = await QuestionService().fetchQuestions(widget.category.id);
     if (questions.isEmpty) {
       throw Exception('Sin preguntas disponibles');
     }
@@ -149,7 +150,17 @@ class _PreguntasScreenState extends State<PreguntasScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Pregunta'),
+        title: Row(
+          children: [
+            CircleAvatar(
+              radius: 16,
+              backgroundImage:
+                  AssetImage('assets/${widget.category.icono}'),
+            ),
+            const SizedBox(width: 8),
+            Text(widget.category.nombre),
+          ],
+        ),
       ),
       body: FutureBuilder<Question>(
         future: _futureQuestion,


### PR DESCRIPTION
## Summary
- display the category icon and name on the question screen header
- adjust `CategoryScreen` to pass the whole category object
- update `CategoryRandomScreen` to work with Category objects

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a2d64aa8832fbe5713ba029504ef