### PR TITLE
Implement random trivia mode

### DIFF
--- a/lib/screen/category_screen.dart
+++ b/lib/screen/category_screen.dart
@@ -3,6 +3,7 @@ import 'preguntas_screen.dart';
 import 'new_question_screen.dart';
 import '../models/category.dart';
 import '../services/category_service.dart';
+import 'dart:math';
 
 class CategoryScreen extends StatefulWidget {
   const CategoryScreen({super.key});
@@ -30,6 +31,46 @@ class _CategoryScreenState extends State<CategoryScreen> {
     if (result == true) {
       setState(() => _correctAnswers++);
     }
+  }
+
+  Future<void> _startRandomTrivia(List<Category> categories) async {
+    int correct = 0;
+    int incorrect = 0;
+    final random = Random();
+    for (var i = 0; i < 10; i++) {
+      if (!mounted) return;
+      final category = categories[random.nextInt(categories.length)];
+      final result = await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => PreguntasScreen(
+            categoryId: category.id,
+            correctCount: correct,
+            incorrectCount: incorrect,
+            questionNumber: i + 1,
+            totalQuestions: 10,
+          ),
+        ),
+      );
+      if (result == true) {
+        correct++;
+      } else {
+        incorrect++;
+      }
+    }
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Resultado'),
+        content: Text('Correctas: $correct\nIncorrectas: $incorrect'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Aceptar'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -87,7 +128,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                   FilledButton.icon(
                     onPressed: () {
                       if (categories.isNotEmpty) {
-                        _openQuestion(categories.first.id);
+                        _startRandomTrivia(categories);
                       }
                     },
                     icon: const Icon(Icons.play_arrow),

--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -5,9 +5,20 @@ import '../models/question.dart';
 import '../services/question_service.dart';
 
 class PreguntasScreen extends StatefulWidget {
-  const PreguntasScreen({super.key, required this.categoryId});
+  const PreguntasScreen({
+    super.key,
+    required this.categoryId,
+    this.correctCount = 0,
+    this.incorrectCount = 0,
+    this.questionNumber = 0,
+    this.totalQuestions = 0,
+  });
 
   final int categoryId;
+  final int correctCount;
+  final int incorrectCount;
+  final int questionNumber;
+  final int totalQuestions;
 
   @override
   State<PreguntasScreen> createState() => _PreguntasScreenState();
@@ -165,6 +176,21 @@ class _PreguntasScreenState extends State<PreguntasScreen>
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    if (widget.totalQuestions > 0)
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Pregunta ${widget.questionNumber} de ${widget.totalQuestions}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Text(
+                            'Correctas: ${widget.correctCount}  Incorrectas: ${widget.incorrectCount}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          const SizedBox(height: 16),
+                        ],
+                      ),
                     Text(
                       question.pregunta,
                       style: const TextStyle(


### PR DESCRIPTION
## Summary
- allow random trivia of 10 questions across categories
- display score per question with correct and incorrect counters

## Testing
- `flutter test` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a38bff24832f81a2c6a2b7363da9