### PR TITLE
Add .env example and configure path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration
+API_BASE_URL=http://127.0.0.1:8000/
+SECRET_KEY=your_secret_key_here

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ navegar entre pantallas dentro de Flutter.
 Para ejecutar las pruebas integradas se utiliza `flutter test`, donde se incluye
 un test de ejemplo en `test/widget_test.dart`.
 
+## Configuración del entorno
+
+La aplicación utiliza el paquete `flutter_dotenv` para cargar variables de
+entorno desde un archivo `.env` ubicado en la raíz del proyecto. Un archivo
+de ejemplo llamado `.env.example` se incluye en el repositorio. Copie este
+archivo y renómbrelo como `.env` para definir la URL base de la API y la clave
+secreta:
+
+```bash
+cp .env.example .env
+```
+
+Recuerde que el archivo `.env` no se encuentra bajo control de versiones.
+
 ## Recursos útiles
 
 - [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ flutter:
     - assets/data/pregunta.json
     - assets/imagenes/
     - assets/sounds/
+    - .env
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- add `.env.example` file
- document how to set up the env file
- include `.env` from project root in `pubspec.yaml`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9ef9b518832f8b1642e13ee1a5df