### PR TITLE
Add profile screen and navigation bar

### DIFF
--- a/lib/screen/category_screen.dart
+++ b/lib/screen/category_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'preguntas_screen.dart';
 import 'new_question_screen.dart';
+import 'user_profile_screen.dart';
 import '../models/category.dart';
 import '../services/category_service.dart';
 
@@ -126,6 +127,28 @@ class _CategoryScreenState extends State<CategoryScreen> {
             );
           },
         ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 0,
+        onTap: (index) {
+          if (index == 1) {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const UserProfileScreen(),
+              ),
+            );
+          }
+        },
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.list),
+            label: 'Trivias',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person),
+            label: 'Ver mi perfil',
+          ),
+        ],
       ),
     );
   }

--- a/lib/screen/user_profile_screen.dart
+++ b/lib/screen/user_profile_screen.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'category_screen.dart';
+
+class UserProfileScreen extends StatefulWidget {
+  const UserProfileScreen({super.key});
+
+  @override
+  State<UserProfileScreen> createState() => _UserProfileScreenState();
+}
+
+class _UserProfileScreenState extends State<UserProfileScreen> {
+  File? _imageFile;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadImage();
+  }
+
+  Future<void> _loadImage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final path = prefs.getString('profile_image');
+    if (path != null) {
+      setState(() => _imageFile = File(path));
+    }
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('profile_image', picked.path);
+      setState(() => _imageFile = File(picked.path));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mi Perfil')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            CircleAvatar(
+              radius: 60,
+              backgroundImage: _imageFile != null ? FileImage(_imageFile!) : null,
+              child: _imageFile == null
+                  ? const Icon(Icons.person, size: 60)
+                  : null,
+            ),
+            const SizedBox(height: 12),
+            TextButton.icon(
+              onPressed: _pickImage,
+              icon: const Icon(Icons.photo_camera),
+              label: const Text('Cambiar foto'),
+            ),
+            const SizedBox(height: 24),
+            ListTile(
+              leading: const Icon(Icons.person),
+              title: const Text('Nombre completo'),
+              subtitle: const Text('Usuario Invitado'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.email),
+              title: const Text('Correo'),
+              subtitle: const Text('invitado@ejemplo.com'),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 1,
+        onTap: (index) {
+          if (index == 0) {
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(builder: (_) => const CategoryScreen()),
+            );
+          }
+        },
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.list),
+            label: 'Trivias',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person),
+            label: 'Ver mi perfil',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   flutter_dotenv: ^5.0.2
   shared_preferences: ^2.2.0
   audioplayers: ^5.1.0
+  image_picker: ^0.8.7+5
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- implement bottom navigation in `CategoryScreen`
- create `UserProfileScreen` to show user info and upload avatar
- add `image_picker` dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed82d1f1c832fa20867ec56ac2d38