### PR TITLE
Pause timer while using wildcard

### DIFF
--- a/lib/screen/preguntas_screen.dart
+++ b/lib/screen/preguntas_screen.dart
@@ -262,6 +262,10 @@ class _PreguntasScreenState extends State<PreguntasScreen>
     final remaining = [correct, incorrectOptions.first]..shuffle();
     final toRemove =
         _currentQuestion!.opciones.where((o) => !remaining.contains(o)).toList();
+    final bool wasAnimating = _timerController.isAnimating;
+    if (wasAnimating) {
+      _timerController.stop();
+    }
     setState(() {
       _wildcardsUsed[index] = true;
       _optionsToRemove = toRemove;
@@ -273,6 +277,9 @@ class _PreguntasScreenState extends State<PreguntasScreen>
         _optionsToRemove = null;
       });
       _wildcardController.reset();
+      if (wasAnimating && !_timerController.isCompleted) {
+        _timerController.forward(from: _timerController.value);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure wildcard animation pauses the question timer before eliminating options
- resume countdown after the 50-50 animation finishes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687edf15cbe8832fa921c98b8c3752c4