### PR TITLE
Disable social login buttons

### DIFF
--- a/lib/screen/login_screen.dart
+++ b/lib/screen/login_screen.dart
@@ -51,13 +51,13 @@ class LoginScreen extends StatelessWidget {
             ElevatedButton.icon(
               icon: const Icon(Icons.mail_outline),
               label: const Text('Registrarse con Google'),
-              onPressed: () => _loginSocial(context),
+              onPressed: null,
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
               icon: const Icon(Icons.facebook),
               label: const Text('Registrarse con Facebook'),
-              onPressed: () => _loginSocial(context),
+              onPressed: null,
             ),
             const SizedBox(height: 16),
             OutlinedButton.icon(


### PR DESCRIPTION
## Summary
- disable Google and Facebook buttons on login screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee438b220832fa7e25d6974e6b851