### PR TITLE
Add result publish feature

### DIFF
--- a/lib/services/result_service.dart
+++ b/lib/services/result_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import 'auth_service.dart';
+
+class ResultService {
+  Future<void> publishResult(int correct, int incorrect, String nickname) async {
+    final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000/';
+    final url = Uri.parse('${baseUrl}api/publicar_resultados');
+    final token = await AuthService().getToken();
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    };
+    if (token != null) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+    final body = {
+      'preguntasCorrectas': correct,
+      'preguntasIncorrectas': incorrect,
+      'nickname': nickname,
+    };
+    final response =
+        await http.post(url, headers: headers, body: jsonEncode(body));
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw Exception('Error al publicar resultados');
+    }
+  }
+}

--- a/lib/widgets/scoreboard_animation.dart
+++ b/lib/widgets/scoreboard_animation.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+class ScoreboardAnimation extends StatefulWidget {
+  final String nickname;
+  final int score;
+  const ScoreboardAnimation({super.key, required this.nickname, required this.score});
+
+  @override
+  State<ScoreboardAnimation> createState() => _ScoreboardAnimationState();
+}
+
+class _ScoreboardAnimationState extends State<ScoreboardAnimation>
+    with SingleTickerProviderStateMixin {
+  late List<Map<String, dynamic>> _players;
+  late AnimationController _trophyController;
+  late Animation<double> _trophyAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _players = [
+      {'name': 'Jugador A', 'score': 0},
+      {'name': 'Jugador B', 'score': 0},
+      {'name': 'Jugador C', 'score': 0},
+      {'name': widget.nickname, 'score': widget.score},
+    ];
+    _trophyController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _trophyAnimation = CurvedAnimation(
+      parent: _trophyController,
+      curve: Curves.easeInOut,
+    );
+    Future.delayed(const Duration(milliseconds: 500), () {
+      setState(() {
+        final player = _players.removeLast();
+        _players.insert(0, player);
+      });
+      _trophyController.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _trophyController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 500),
+          child: Column(
+            key: ValueKey(_players.first['name']),
+            children: _players.asMap().entries.map((entry) {
+              final index = entry.key;
+              final player = entry.value;
+              final highlight = player['name'] == widget.nickname && index == 0;
+              return AnimatedContainer(
+                key: ValueKey(player['name']),
+                duration: const Duration(milliseconds: 500),
+                margin: const EdgeInsets.symmetric(vertical: 4),
+                decoration: BoxDecoration(
+                  color: highlight ? Colors.amber.shade100 : Colors.grey.shade200,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: ListTile(
+                  leading: Text('#${index + 1}'),
+                  title: Text(player['name']),
+                  trailing: Text(player['score'].toString()),
+                ),
+              );
+            }).toList(),
+          ),
+        ),
+        const SizedBox(height: 16),
+        SizeTransition(
+          sizeFactor: _trophyAnimation,
+          axisAlignment: -1.0,
+          child: Column(
+            children: const [
+              Icon(Icons.emoji_events, size: 60, color: Colors.amber),
+              SizedBox(height: 8),
+              Text(
+                'Felicidades eres el puesto numero 1',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- publish results via `ResultService`
- animate scoreboard ranking with `ScoreboardAnimation`
- update question screen to allow publishing results and showing animation

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ee96d72ac832faa8f4261a5ab0d62