### PR TITLE
Highlight user entry in results animation

### DIFF
--- a/lib/widgets/scoreboard_animation.dart
+++ b/lib/widgets/scoreboard_animation.dart
@@ -85,7 +85,7 @@ class _ScoreboardAnimationState extends State<ScoreboardAnimation>
             children: _players.asMap().entries.map((entry) {
               final index = entry.key;
               final player = entry.value;
-              final highlight = player['name'] == widget.nickname && index == 0;
+              final highlight = player['name'] == widget.nickname;
               return AnimatedContainer(
                 key: ValueKey(player['name']),
                 duration: const Duration(milliseconds: 500),


### PR DESCRIPTION
## Summary
- keep the user's row highlighted throughout the scoreboard animation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef24c0a04832fbb80a944aa4d32cb